### PR TITLE
fs: collapse a run of separators when fs.add joins a path

### DIFF
--- a/lib/src/fs/path.valk
+++ b/lib/src/fs/path.valk
@@ -121,26 +121,49 @@ use valk.io
 /// Joins `dir` and `fn` with exactly one separator between them.
 ///
 /// Either platform's separator is recognized at the joint; a missing one is added as
-/// `PATH_DIV`. An empty `dir` gives `fn` unchanged.
+/// `PATH_DIV`. A run of separators at the joint is collapsed to one separator: `PATH_DIV`
+/// when the run holds it, otherwise the run's own last byte, so a run of the other kind
+/// comes through as written. An empty `dir` gives `fn` unchanged, and a `dir` of nothing but
+/// separators is kept whole so a root stays a root (`//` and `C:\` keep every separator
+/// they have).
 + fn add(dir: String, fn: String) String {
     if dir.bytes == 0 : return fn
-    let s1 = dir.ends_with(PATH_DIV) || dir.ends_with(PATH_DIV_REPLACE)
-    let s2 = fn.starts_with(PATH_DIV) || fn.starts_with(PATH_DIV_REPLACE)
-    if !s1 && !s2 : return dir + PATH_DIV + fn
-    if s1 && s2 {
-        // Strip every leading separator of either kind: one trim per kind leaves the
-        // other one behind, which then doubles the joint
-        let div = PATH_DIV.get(0)
-        let other = PATH_DIV_REPLACE.get(0)
-        let start: uint = 0
-        while start < fn.bytes {
-            let ch = fn.get(start)
-            if ch != div && ch != other : break
-            start++
-        }
-        return dir + fn.range(start, fn.bytes - start)
+    let div = PATH_DIV.get(0)
+    let other = PATH_DIV_REPLACE.get(0)
+
+    // The run of separators at the end of `dir` and at the start of `fn`
+    let dir_end = dir.bytes
+    while dir_end > 0 && is_path_div(dir.get(dir_end - 1), div, other) : dir_end--
+    let fn_start: uint = 0
+    while fn_start < fn.bytes && is_path_div(fn.get(fn_start), div, other) : fn_start++
+    let dir_run = dir.bytes - dir_end
+    let fn_run = fn_start
+
+    // A dir of nothing but separators keeps them all, so a root stays a root
+    if dir_run == dir.bytes : return dir + fn.range(fn_start, fn.bytes - fn_start)
+    // Neither side has a separator, so exactly one is added
+    if dir_run == 0 && fn_run == 0 : return dir + PATH_DIV + fn
+    // A single separator already is the joint
+    if dir_run + fn_run == 1 : return dir + fn
+    // Collapse the run that holds the joint, dropping fn's run with it
+    if dir_run == 0 {
+        return dir + run_joint(fn.range(0, fn_run), div).to_ascii_string()
+            + fn.range(fn_start, fn.bytes - fn_start)
     }
-    return dir + fn
+    return dir.range(0, dir_end) + run_joint(dir.range(dir_end, dir_run), div).to_ascii_string()
+        + fn.range(fn_start, fn.bytes - fn_start)
+}
+
+// The separator a run collapses to: the platform separator when the run holds one, since
+// that is what keeps the two sides apart, and otherwise the run's own last byte, so a run
+// made of the other kind is left as the caller wrote it
+fn run_joint(run: String, div: u8) u8 {
+    if run.contains_byte(div) : return div
+    return run.get(run.bytes - 1)
+}
+
+fn is_path_div(ch: u8, div: u8, other: u8) bool {
+    return ch == div || ch == other
 }
 
 /// Returns the current working directory.

--- a/tests/src/fs-path.valk
+++ b/tests/src/fs-path.valk
@@ -90,6 +90,52 @@ test "fs: add never doubles the separator at the joint" {
     // doubled the joint
     assert(fs.add(dir, fs.PATH_DIV_REPLACE + fs.PATH_DIV + "b") == joined)
     assert(fs.add(dir, fs.PATH_DIV + fs.PATH_DIV_REPLACE + "b") == joined)
+    // A run on both sides of the joint, from the fix that first stripped one kind
+    assert(fs.add("/etc/", fs.PATH_DIV_REPLACE + fs.PATH_DIV + "passwd") == "/etc/passwd")
+}
+
+test "fs: add collapses a run of separators at the joint" {
+    let joined = "a" + fs.PATH_DIV + "b"
+    // A run on either side, and on both, leaves one separator
+    assert(fs.add("a" + fs.PATH_DIV + fs.PATH_DIV, "b") == joined)
+    assert(fs.add("a" + fs.PATH_DIV + fs.PATH_DIV + fs.PATH_DIV, "b") == joined)
+    assert(fs.add("a", fs.PATH_DIV + fs.PATH_DIV + "b") == joined)
+    assert(fs.add("a" + fs.PATH_DIV + fs.PATH_DIV, fs.PATH_DIV + fs.PATH_DIV + "b") == joined)
+    // One separator each is already a single joint
+    assert(fs.add("a" + fs.PATH_DIV, fs.PATH_DIV + "b") == joined)
+
+    // The joint keeps the byte the caller wrote instead of rewriting it to PATH_DIV:
+    // outside Windows a backslash is an ordinary name byte, so rewriting it renames
+    let other_joined = "a" + fs.PATH_DIV_REPLACE + "b"
+    assert(fs.add("a", fs.PATH_DIV_REPLACE + fs.PATH_DIV_REPLACE + "b") == other_joined)
+    assert(fs.add("a" + fs.PATH_DIV_REPLACE + fs.PATH_DIV_REPLACE, "b") == other_joined)
+    assert(fs.add("a" + fs.PATH_DIV_REPLACE, fs.PATH_DIV_REPLACE + "b") == other_joined)
+
+    // A run mixed with the other kind keeps the platform separator, so the two sides stay
+    // apart and the order inside the run does not decide the result
+    assert(fs.add("a", fs.PATH_DIV_REPLACE + fs.PATH_DIV + fs.PATH_DIV + "b") == joined)
+    assert(fs.add("a" + fs.PATH_DIV + fs.PATH_DIV_REPLACE, "b") == joined)
+    assert(fs.add("a" + fs.PATH_DIV_REPLACE + fs.PATH_DIV, "b") == joined)
+    assert(fs.add("a", fs.PATH_DIV_REPLACE + fs.PATH_DIV + "b") == joined)
+    assert(fs.add("a", fs.PATH_DIV + fs.PATH_DIV_REPLACE + "b") == joined)
+    // The dir's run is what holds the joint here, and its separator survives
+    assert(fs.add("a" + fs.PATH_DIV + fs.PATH_DIV_REPLACE + fs.PATH_DIV, "b") == joined)
+}
+
+test "fs: add keeps a dir of separators whole" {
+    #if OS == "win"
+    // A drive root keeps its separator, and the joined name is appended to it
+    assert(fs.add("C:\\", "test") == "C:\\test")
+    assert(fs.add("C:\\", "\\test") == "C:\\test")
+    assert(fs.add("C:\\", "\\\\test") == "C:\\test")
+    #else
+    // `//` is the POSIX special root, so it must not collapse to `/`
+    assert(fs.add("//", "b") == "//b")
+    assert(fs.add("//", "//b") == "//b")
+    assert(fs.add("/", "b") == "/b")
+    assert(fs.add("/", "/b") == "/b")
+    assert(fs.add("///", "b") == "///b")
+    #end
 }
 
 test "fs: basename of a path without a separator is the whole path" {


### PR DESCRIPTION
add only stripped separators from the path being appended, so a run on either side of the joint survived it: fs.add("a//", "b") and fs.add("a", "//b") both gave "a//b" against the documented "exactly one separator".

Collapse the run to one separator: PATH_DIV when the run holds it, otherwise the run's own last byte. Preferring PATH_DIV keeps the two sides apart, so a mixed run does not depend on the order inside it -- add("a/\\", "b") and add("a\\/", "b") both give "a/b" -- and falling back to the run's last byte leaves a run of the other kind as written, since outside Windows a backslash is an ordinary name byte in a path.

A dir of nothing but separators is still kept whole, so the POSIX special root and a Windows drive root survive: add("//", "b") stays "//b" and add("C:\\", "test") stays "C:\\test".